### PR TITLE
Expose advanced proxy configuration settings

### DIFF
--- a/chrome/options.html
+++ b/chrome/options.html
@@ -556,11 +556,35 @@
         </div>
         <div class="tab w-full overflow-hidden border-t">
             <input class="absolute opacity-0" id="tab-single-four" type="radio" name="tabs2">
-            <label class="block leading-normal cursor-pointer" for="tab-single-four">SCION Path Usage</label>
-            <div class="tab-content overflow-hidden border-l-2 bg-gray-100 border-indigo-500 leading-normal">
-                <div class="flex p-2">
-
+            <label class="block leading-normal cursor-pointer" for="tab-single-four">Proxy Configuration (Advanced)</label>
+            <div class="tab-content overflow-hidden border-l-2 border-indigo-500 leading-normal">
+                <div class="flex justify-end mb-3">
+                    <button id="reset-proxy-defaults" class="px-3 py-1 text-xs text-gray-600 border border-gray-300 rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-300">
+                        Set to Default
+                    </button>
                 </div>
+        
+                <div class="mb-3">
+                <label class="block text-sm font-medium text-gray-700 mb-1">Protocol</label>
+                    <select id="proxy-scheme" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+                        <option value="http">HTTP</option>
+                        <option value="https" selected>HTTPS</option>
+                    </select>
+                </div>
+                
+                <div class="mb-3">
+                <label class="block text-sm font-medium text-gray-700 mb-1">Proxy Host</label>
+                <input type="text" id="proxy-host" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="forward-proxy.scion">
+                </div>
+                
+                <div class="mb-3">
+                <label class="block text-sm font-medium text-gray-700 mb-1">Port</label>
+                <input type="text" id="proxy-port" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="9443">
+                </div>
+                
+                <button id="save-proxy-settings" class="px-4 py-2 bg-blue-100 text-blue-700 rounded-md hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                Save Proxy Settings
+                </button>
             </div>
         </div>
     </div>

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -4,6 +4,11 @@
 // Copyright 2024 ETH Zurich, Ovgu
 'use strict';
 
+// Default proxy configuration values
+const DEFAULT_PROXY_SCHEME = 'https';
+const DEFAULT_PROXY_HOST = 'forward-proxy.scion';
+const DEFAULT_PROXY_PORT = '9443';
+
 const toggleGlobalStrict = document.getElementById('toggleGlobalStrict');
 const checkboxGlobalStrict = document.getElementById('checkboxGlobalStrict');
 const lineStrictMode = document.getElementById('lineStrictMode');
@@ -13,6 +18,9 @@ const toggleNewDomainStrictMode = document.getElementById('toggleNewDomainStrict
 const lineNewDomainStrictMode = document.getElementById('lineNewDomainStrictMode');
 const inputNewDomain = document.getElementById('inputNewDomain');
 const scionMode = document.getElementById('scionmode');
+const proxySchemeElement = document.getElementById('proxy-scheme');
+const proxyHostElement = document.getElementById('proxy-host');
+const proxyPortElement = document.getElementById('proxy-port');
 
 
 const tableSitePreferencesRow = ` 
@@ -222,3 +230,53 @@ checkBoxNewDomainStrictMode
             scionMode.innerHTML = 'when available';
         }
     });
+
+// Load saved settings
+document.addEventListener('DOMContentLoaded', function() {
+    chrome.storage.sync.get({
+      proxyScheme: 'https',
+      proxyHost: 'forward-proxy.scion',
+      proxyPort: '9443'
+    }, function(items) {
+      proxySchemeElement.value = items.proxyScheme;
+      proxyHostElement.value = items.proxyHost;
+      proxyPortElement.value = items.proxyPort;
+    });
+    
+    document.getElementById('save-proxy-settings').addEventListener('click', saveProxySettings);
+    document.getElementById('reset-proxy-defaults').addEventListener('click', resetProxyDefaults);
+});
+  
+function saveProxySettings() {
+    const scheme = proxySchemeElement.value;
+    const host = proxyHostElement.value;
+    const port = proxyPortElement.value;
+
+    // Basic validation
+    if (!host || !port) {
+        alert('Proxy host and port are required');
+        return;
+    }
+
+    chrome.storage.sync.set({
+        proxyScheme: scheme,
+        proxyHost: host,
+        proxyPort: port
+    }, function() {
+        // Show saved message
+        const saveButton = document.getElementById('save-proxy-settings');
+        const originalText = saveButton.textContent;
+        saveButton.textContent = 'Settings Saved!';
+        saveButton.disabled = true;
+        
+        setTimeout(function() {
+        saveButton.textContent = originalText;
+        saveButton.disabled = false;
+        }, 1500);
+    });
+}
+function resetProxyDefaults() {
+    proxySchemeElement.value = DEFAULT_PROXY_SCHEME;
+    proxyHostElement.value = DEFAULT_PROXY_HOST;
+    proxyPortElement.value = DEFAULT_PROXY_PORT;
+}

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -1,10 +1,9 @@
 // Copyright 2024 ETH Zurich, Ovgu
 'use strict';
 
-const proxyScheme = "https"
-const proxyHost = "forward-proxy.scion";
-const proxyPort = "9443";
-const proxyAddress = `${proxyScheme}://${proxyHost}:${proxyPort}`
+const DEFAULT_PROXY_SCHEME = "https"
+const DEFAULT_PROXY_HOST = "forward-proxy.scion";
+const DEFAULT_PROXY_PORT = "9443";
 const proxyPathUsagePath = "/path-usage"
 
 const toggleRunning = document.getElementById('toggleRunning');
@@ -16,6 +15,8 @@ const pathUsageContainer = document.getElementById("path-usage-container");
 const scionModePreference = document.getElementById('scionModePreference');
 const domainList = document.getElementById("domainlist");
 const scionsupport = document.getElementById("scionsupport");
+
+let proxyAddress = `${proxyScheme}://${proxyHost}:${proxyPort}`
 
 var perSiteStrictMode = {};
 var popupMainDomain = "";
@@ -45,7 +46,19 @@ document.getElementById('button-options').addEventListener('click', function () 
 })();
 
 window.onload = function () {
-    updatePathUsage();
+    chrome.storage.sync.get({
+        proxyScheme: DEFAULT_PROXY_SCHEME,
+        proxyHost: DEFAULT_PROXY_HOST,
+        proxyPort: DEFAULT_PROXY_PORT
+      }, (items) => {
+        let proxyScheme = items.proxyScheme;
+        let proxyHost = items.proxyHost;
+        let proxyPort = items.proxyPort;
+        proxyAddress = `${proxyScheme}://${proxyHost}:${proxyPort}`;
+
+        updatePathUsage();
+    });
+    
 }
 
 const updatePathUsage = () => {

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -16,7 +16,7 @@ const scionModePreference = document.getElementById('scionModePreference');
 const domainList = document.getElementById("domainlist");
 const scionsupport = document.getElementById("scionsupport");
 
-let proxyAddress = `${proxyScheme}://${proxyHost}:${proxyPort}`
+let proxyAddress = `${DEFAULT_PROXY_SCHEME}://${DEFAULT_PROXY_HOST}:${DEFAULT_PROXY_PORT}`
 
 var perSiteStrictMode = {};
 var popupMainDomain = "";


### PR DESCRIPTION
This PR enables an advanced configuration setting for changing the proxy address for the extension. This allows for other deployments than doesn't follow the default deployment model, i.e., discovering the proxy at "forward-proxy.scion". This is labeled as advanced because an incorrect configuration can break the functionality.