### PR TITLE
[docs] Fix typo in index project name

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,8 +2,8 @@
 
 # -- Project information
 
-project = 'SCION Borwser Extension'
-copyright = '2024, ETHZ'
+project = 'SCION Browser Extension'
+copyright = '2025, ETHZ'
 author = 'ETH Zurich'
 
 release = '0.1'


### PR DESCRIPTION
Fix typo in project title and page title.