### PR TITLE
migration of local storage to IDB with LRU-based rule eviction

### DIFF
--- a/chrome/background.ts
+++ b/chrome/background.ts
@@ -7,22 +7,13 @@ import {EXTENSION_RUNNING, getSyncValue, GLOBAL_STRICT_MODE, ISD_ALL, ISD_WHITEL
 import {globalStrictModeUpdated, initializeDnr, perSiteStrictModeUpdated, updateProxySettingsInDnrRules} from "./background_helpers/dnr_handler.js";
 import {initializeRequestInterceptionListeners} from "./background_helpers/request_interception_handler.js";
 import {initializeTabListeners} from "./background_helpers/tab_handler.js";
+import {initializeStrictModes, setGlobalStrictMode, setPerSiteStrictMode} from "./shared/utilities.js";
 
-export let GlobalStrictMode: SyncValueSchema[typeof GLOBAL_STRICT_MODE] = false;
-export let PerSiteStrictMode: SyncValueSchema[typeof PER_SITE_STRICT_MODE] = {};
 
 /*--- setup ------------------------------------------------------------------*/
 
 const initializeExtension = async () => {
-    const storageGlobalStrictMode = await getSyncValue(GLOBAL_STRICT_MODE);
-    GlobalStrictMode = storageGlobalStrictMode ?? false;
-    if (storageGlobalStrictMode === undefined) await saveSyncValue(GLOBAL_STRICT_MODE, GlobalStrictMode);
-    console.log(`[initializeExtension]: GlobalStrictMode: ${GlobalStrictMode}`);
-
-    const storagePerSiteStrictMode = await getSyncValue(PER_SITE_STRICT_MODE);
-    PerSiteStrictMode = storagePerSiteStrictMode ?? {};
-    if (storagePerSiteStrictMode === undefined) await saveSyncValue(PER_SITE_STRICT_MODE, PerSiteStrictMode);
-    console.log(`[initializeExtension]: PerSiteStrictMode: ${PerSiteStrictMode}`);
+    await initializeStrictModes();
 
     /*--- PAC --------------------------------------------------------------------*/
     // initializing proxy handler before DNR, as some DNR rules rely on the `proxyAddress`
@@ -60,14 +51,16 @@ chrome.storage.onChanged.addListener(async (changes, namespace) => {
 
         } else if (changes.perSiteStrictMode?.newValue !== undefined) {
 
-            PerSiteStrictMode = (changes.perSiteStrictMode.newValue || {}) as SyncValueSchema[typeof PER_SITE_STRICT_MODE];
+            const perSiteStrictMode = (changes.perSiteStrictMode.newValue || {}) as SyncValueSchema[typeof PER_SITE_STRICT_MODE];
+            setPerSiteStrictMode(perSiteStrictMode);
 
             // update DNR rules
             await perSiteStrictModeUpdated();
 
         } else if (changes.globalStrictMode?.newValue !== undefined) {
 
-            GlobalStrictMode = changes.globalStrictMode.newValue as SyncValueSchema[typeof GLOBAL_STRICT_MODE];
+            const globalStrictMode = changes.globalStrictMode.newValue as SyncValueSchema[typeof GLOBAL_STRICT_MODE];
+            setGlobalStrictMode(globalStrictMode);
 
             // update DNR rules
             await globalStrictModeUpdated();

--- a/chrome/background.ts
+++ b/chrome/background.ts
@@ -8,12 +8,16 @@ import {globalStrictModeUpdated, initializeDnr, perSiteStrictModeUpdated, update
 import {initializeRequestInterceptionListeners} from "./background_helpers/request_interception_handler.js";
 import {initializeTabListeners} from "./background_helpers/tab_handler.js";
 import {initializeStrictModes, setGlobalStrictMode, setPerSiteStrictMode} from "./shared/utilities.js";
+import {evictExpiredEntries} from "./shared/database.js";
 
 
 /*--- setup ------------------------------------------------------------------*/
 
 const initializeExtension = async () => {
     await initializeStrictModes();
+
+    // on startup of the SW, check for expired entries and evict them
+    await evictExpiredEntries();
 
     /*--- PAC --------------------------------------------------------------------*/
     // initializing proxy handler before DNR, as some DNR rules rely on the `proxyAddress`

--- a/chrome/background.ts
+++ b/chrome/background.ts
@@ -3,7 +3,7 @@
 
 import {initializeProxyHandler, loadProxySettings} from "./background_helpers/proxy_handler.js";
 import {allowAllgeofence, geofence, resetPolicyCookie} from "./background_helpers/geofence_handler.js";
-import {EXTENSION_RUNNING, getSyncValue, GLOBAL_STRICT_MODE, ISD_ALL, ISD_WHITELIST, PER_SITE_STRICT_MODE, saveSyncValue, type SyncValueSchema} from "./shared/storage.js";
+import {GLOBAL_STRICT_MODE, ISD_ALL, ISD_WHITELIST, PER_SITE_STRICT_MODE, type SyncValueSchema} from "./shared/storage.js";
 import {globalStrictModeUpdated, initializeDnr, perSiteStrictModeUpdated, updateProxySettingsInDnrRules} from "./background_helpers/dnr_handler.js";
 import {initializeRequestInterceptionListeners} from "./background_helpers/request_interception_handler.js";
 import {initializeTabListeners} from "./background_helpers/tab_handler.js";
@@ -21,25 +21,17 @@ const initializeExtension = async () => {
     /*--- END PAC ----------------------------------------------------------------*/
 
     await initializeDnr();
+
+    // set initial icon to the neutral blue variant
+    await chrome.action.setIcon({path: "/images/scion-38.jpg"});
 };
 initializeExtension();
-
-// Do icon setup etc at startup
-getSyncValue(EXTENSION_RUNNING).then(async extensionRunning => {
-    await updateRunningIcon(extensionRunning);
-});
 
 /*--- storage ----------------------------------------------------------------*/
 
 chrome.storage.onChanged.addListener(async (changes, namespace) => {
-    // In case we disable running for the extension, lets put an empty set for now
-    // Later, we could remove the PAC script, but doesn't impact us now...
     if (namespace === "sync") {
-        if (changes.extension_running?.newValue !== undefined) {
-
-            await updateRunningIcon(changes.extension_running.newValue);
-
-        } else if (changes.isd_all?.newValue !== undefined) {
+        if (changes.isd_all?.newValue !== undefined) {
 
             const isdAll = changes.isd_all.newValue as SyncValueSchema[typeof ISD_ALL];
             allowAllgeofence(isdAll);
@@ -74,16 +66,7 @@ chrome.storage.onChanged.addListener(async (changes, namespace) => {
             await updateProxySettingsInDnrRules();
         }
     }
-})
-
-// Changes icon depending on the extension is running or not
-async function updateRunningIcon(extensionRunning: any) {
-    if (extensionRunning) {
-        await chrome.action.setIcon({path: "/images/scion-38.jpg"});
-    } else {
-        await chrome.action.setIcon({path: "/images/scion-38_disabled.jpg"});
-    }
-}
+});
 
 /*--- END storage ------------------------------------------------------------*/
 

--- a/chrome/background_helpers/dnr_handler.ts
+++ b/chrome/background_helpers/dnr_handler.ts
@@ -112,7 +112,7 @@ export async function perSiteStrictModeUpdated() {
                 // in the domainSpecificRules
                 const isScion = await isHostScion(strictHost, strictHost, chrome.tabs.TAB_ID_NONE);
                 const id = (await getNFreeIds(1))[0];
-                if (isScion) domainSpecificRules.push(createAllowRule(strictHost, id))
+                if (isScion) domainSpecificRules.push(createAllowRule(strictHost, id));
                 else domainSpecificRules.push(createBlockRule(strictHost, id));
             }
         }

--- a/chrome/background_helpers/dnr_handler.ts
+++ b/chrome/background_helpers/dnr_handler.ts
@@ -1,7 +1,7 @@
-import {DOMAIN, getRequests, type RequestSchema} from "../shared/storage.js";
+import {DOMAIN, getRequestsInDB, type RequestSchema} from "../shared/database.js";
 import {proxyAddress, proxyHost, proxyURLResolveParam, proxyURLResolvePath, WPAD_URL} from "./proxy_handler.js";
 import {isHostScion} from "./request_interception_handler.js";
-import {GlobalStrictMode, PerSiteStrictMode, normalizedHostname} from "../shared/utilities.js";
+import {GlobalStrictMode, normalizedHostname, PerSiteStrictMode} from "../shared/utilities.js";
 import ResourceType = chrome.declarativeNetRequest.ResourceType;
 
 type Rule = chrome.declarativeNetRequest.Rule;
@@ -39,30 +39,14 @@ const SUBRESOURCES_REDIRECT_RULE_ID = 3;
 // sufficiently high to have space for generic DNR rules (specified above)
 const DOMAIN_SPECIFIC_RULES_START_ID = 10000;
 
-const EXT_PAGE = chrome.runtime.getURL('/checking.html');
+const CHECKING_PAGE = chrome.runtime.getURL('/checking.html');
 
 // extracting the hostname from the WPAD URL, as it needs to be excluded from matching rules
 // note that this might cause other resources that share the same hostname to be excluded too
 const WPAD_HOSTNAME = new URL(WPAD_URL).hostname;
 
 const MAIN_FRAME_TYPE: ResourceType[] = [ResourceType.MAIN_FRAME];
-const ALL_RESOURCE_TYPES = [
-    ResourceType.MAIN_FRAME,
-    ResourceType.SUB_FRAME,
-    ResourceType.XMLHTTPREQUEST,
-    ResourceType.SCRIPT,
-    ResourceType.IMAGE,
-    ResourceType.FONT,
-    ResourceType.MEDIA,
-    ResourceType.STYLESHEET,
-    ResourceType.OBJECT,
-    ResourceType.OTHER,
-    ResourceType.PING,
-    ResourceType.WEBSOCKET,
-    ResourceType.WEBTRANSPORT,
-    ResourceType.WEBBUNDLE,
-    ResourceType.CSP_REPORT,
-];
+const ALL_RESOURCE_TYPES: ResourceType[] = [ResourceType.MAIN_FRAME, ResourceType.SUB_FRAME, ResourceType.XMLHTTPREQUEST, ResourceType.SCRIPT, ResourceType.IMAGE, ResourceType.FONT, ResourceType.MEDIA, ResourceType.STYLESHEET, ResourceType.OBJECT, ResourceType.OTHER, ResourceType.PING, ResourceType.WEBSOCKET, ResourceType.WEBTRANSPORT, ResourceType.WEBBUNDLE, ResourceType.CSP_REPORT];
 
 /**
  * Initializes the DNR handler.
@@ -128,8 +112,12 @@ export async function perSiteStrictModeUpdated() {
             else if (Object.keys(allowedHostsWithId).includes(strictHost)) domainSpecificRules.push(createAllowRule(strictHost, allowedHostsWithId[strictHost]));
             else {
                 // using chrome.tabs.TAB_ID_NONE as the tab id, as no tab can be associated with this request
-                // isHostScion already adds the appropriate DNR rules based on the lookup result (including creating the DB entry for the host)
-                await isHostScion(strictHost, strictHost, chrome.tabs.TAB_ID_NONE, true);
+                // cannot use isHostScionHandleDnrRule here, since otherwise the call to updateRules below will remove the rule again, as it is not
+                // in the domainSpecificRules
+                const isScion = await isHostScion(strictHost, strictHost, chrome.tabs.TAB_ID_NONE);
+                const id = (await getNFreeIds(1))[0];
+                if (isScion) domainSpecificRules.push(createAllowRule(strictHost, id))
+                else domainSpecificRules.push(createBlockRule(strictHost, id));
             }
         }
 
@@ -195,8 +183,8 @@ export async function addDnrRule(host: string, scionEnabled: boolean, alreadyHas
 
         // if a rule for the `host` already exists, do not add another rule
         const currentRules = await chrome.declarativeNetRequest.getDynamicRules();
-        const currentUrlFilters = currentRules.map(rule => rule.condition.urlFilter);
-        if (currentUrlFilters.includes(urlFilterFromHost(host))) return;
+        const currentFilters = currentRules.map(rule => rule.condition.urlFilter);
+        if (currentFilters.includes(urlFilterFromHost(host))) return;
 
         const rule = scionEnabled ? createAllowRule(host, id) : createBlockRule(host, id);
         await chrome.declarativeNetRequest.updateDynamicRules({addRules: [rule], removeRuleIds: []})
@@ -252,7 +240,7 @@ function createMainFrameRedirectRule(): Rule {
             type: 'redirect',
             redirect: {
                 // match entire URL and append it to a hash (separator character expected by checking.js)
-                regexSubstitution: EXT_PAGE + '#\\0',
+                regexSubstitution: CHECKING_PAGE + '#\\0',
             },
         },
         condition: {
@@ -322,7 +310,7 @@ function createSubResourcesInitiatorRedirectRule(blockedInitiators: string[]): R
  * Note that this function is unsafe and must be wrapped with `withLock`.
  */
 async function getAllowedAndBlockedHostsWithId() {
-    const requests: RequestSchema[] = await getRequests();
+    const requests: RequestSchema[] = await getRequestsInDB();
     let allowedHostsWithId: Record<string, number> = {};
     let blockedHostsWithId: Record<string, number> = {};
     const freeIds: number[] = await getNFreeIds(requests.length);

--- a/chrome/background_helpers/dnr_handler.ts
+++ b/chrome/background_helpers/dnr_handler.ts
@@ -1,8 +1,7 @@
 import {DOMAIN, getRequests, type RequestSchema} from "../shared/storage.js";
 import {proxyAddress, proxyHost, proxyURLResolveParam, proxyURLResolvePath, WPAD_URL} from "./proxy_handler.js";
 import {isHostScion} from "./request_interception_handler.js";
-import {normalizedHostname} from "../shared/utilities.js";
-import {GlobalStrictMode, PerSiteStrictMode} from "../background.js";
+import {GlobalStrictMode, PerSiteStrictMode, normalizedHostname} from "../shared/utilities.js";
 import ResourceType = chrome.declarativeNetRequest.ResourceType;
 
 type Rule = chrome.declarativeNetRequest.Rule;

--- a/chrome/background_helpers/dnr_handler.ts
+++ b/chrome/background_helpers/dnr_handler.ts
@@ -1,5 +1,5 @@
 import {DOMAIN, getRequestsInDB, type RequestSchema} from "../shared/database.js";
-import {proxyAddress, proxyHost, proxyURLResolveParam, proxyURLResolvePath, WPAD_URL} from "./proxy_handler.js";
+import {proxyAddress, proxyHost, proxyURLResolveParam, proxyURLResolvePath, WPAD_HOSTNAME} from "./proxy_handler.js";
 import {isHostScion} from "./request_interception_handler.js";
 import {GlobalStrictMode, normalizedHostname, PerSiteStrictMode} from "../shared/utilities.js";
 import ResourceType = chrome.declarativeNetRequest.ResourceType;
@@ -40,10 +40,6 @@ const SUBRESOURCES_REDIRECT_RULE_ID = 3;
 const DOMAIN_SPECIFIC_RULES_START_ID = 10000;
 
 const CHECKING_PAGE = chrome.runtime.getURL('/checking.html');
-
-// extracting the hostname from the WPAD URL, as it needs to be excluded from matching rules
-// note that this might cause other resources that share the same hostname to be excluded too
-const WPAD_HOSTNAME = new URL(WPAD_URL).hostname;
 
 const MAIN_FRAME_TYPE: ResourceType[] = [ResourceType.MAIN_FRAME];
 const ALL_RESOURCE_TYPES: ResourceType[] = [ResourceType.MAIN_FRAME, ResourceType.SUB_FRAME, ResourceType.XMLHTTPREQUEST, ResourceType.SCRIPT, ResourceType.IMAGE, ResourceType.FONT, ResourceType.MEDIA, ResourceType.STYLESHEET, ResourceType.OBJECT, ResourceType.OTHER, ResourceType.PING, ResourceType.WEBSOCKET, ResourceType.WEBTRANSPORT, ResourceType.WEBBUNDLE, ResourceType.CSP_REPORT];
@@ -132,6 +128,15 @@ export async function perSiteStrictModeUpdated() {
 
         await updateRules(genericRules, domainSpecificRules);
     });
+}
+
+/**
+ * Removes all currently enabled DNR rules.
+ *
+ * To reset the rules to match the information in storage, call {@link globalStrictModeUpdated}.
+ */
+export async function removeAllRules() {
+    await updateRules([], []);
 }
 
 /**

--- a/chrome/background_helpers/proxy_handler.ts
+++ b/chrome/background_helpers/proxy_handler.ts
@@ -1,6 +1,9 @@
-import {getSyncValues, PROXY_HOST, PROXY_PORT, PROXY_SCHEME, saveSyncValues, type SyncValueSchema} from "../shared/storage.js";
+import {AUTO_PROXY_CONFIG, getSyncValue, getSyncValues, PROXY_HOST, PROXY_PORT, PROXY_SCHEME, saveSyncValues, type SyncValueSchema} from "../shared/storage.js";
 import Mode = chrome.proxy.Mode;
 
+export type OnMessageMessageType = {
+    action: string;
+}
 type ProxyConfig = {
     [PROXY_SCHEME]: SyncValueSchema[typeof PROXY_SCHEME];
     [PROXY_HOST]: SyncValueSchema[typeof PROXY_HOST];
@@ -31,17 +34,17 @@ export const WPAD_URL = `http://wpad/wpad_scion.dat`;
 
 export async function initializeProxyHandler() {
     // Load saved configuration at startup
-    const {autoProxyConfig} = await chrome.storage.sync.get({autoProxyConfig: true});
+    const autoProxyConfig = await getSyncValue(AUTO_PROXY_CONFIG, true);
     if (autoProxyConfig) {
         await fetchAndApplyScionPAC();
     } else {
         await loadProxySettings();
     }
 
-    chrome.runtime.onMessage.addListener(async function (request, sender, sendResponse) {
-        if (request.action === "fetchAndApplyScionPAC") {
-            await fetchAndApplyScionPAC();
-            return true;
+    chrome.runtime.onMessage.addListener(function (request: any) {
+        const message = request as OnMessageMessageType;
+        if (message.action === "fetchAndApplyScionPAC") {
+            fetchAndApplyScionPAC();
         }
     });
 }

--- a/chrome/background_helpers/proxy_handler.ts
+++ b/chrome/background_helpers/proxy_handler.ts
@@ -1,4 +1,6 @@
 import {AUTO_PROXY_CONFIG, getSyncValue, getSyncValues, PROXY_HOST, PROXY_PORT, PROXY_SCHEME, saveSyncValues, type SyncValueSchema} from "../shared/storage.js";
+import {GlobalStrictMode, PerSiteStrictMode} from "../shared/utilities.js";
+import {globalStrictModeUpdated, removeAllRules} from "./dnr_handler.js";
 import Mode = chrome.proxy.Mode;
 
 export type OnMessageMessageType = {
@@ -31,6 +33,9 @@ export let proxyPort = HTTPS_PROXY_PORT;
 export let proxyAddress = `${proxyScheme}://${proxyHost}:${proxyPort}`;
 
 export const WPAD_URL = `http://wpad/wpad_scion.dat`;
+// extracting the hostname from the WPAD URL, as it needs to be excluded from matching rules
+// note that this might cause other resources that share the same hostname to be excluded too
+export const WPAD_HOSTNAME = new URL(WPAD_URL).hostname;
 
 export async function initializeProxyHandler() {
     // Load saved configuration at startup
@@ -49,17 +54,31 @@ export async function initializeProxyHandler() {
     });
 }
 
-export async function loadProxySettings() {
+/**
+ * Loads and populates the {@link proxyScheme}, {@link proxyHost}, {@link proxyPort}, and therefore the {@link proxyAddress}
+ * without updating the configuration itself. For this, consider {@link loadProxySettings}.
+ */
+export async function loadProxySettingsNoUpdate() {
     const items = await getSyncValues({
         [PROXY_SCHEME]: HTTPS_PROXY_SCHEME,
         [PROXY_HOST]: DEFAULT_PROXY_HOST,
         [PROXY_PORT]: HTTPS_PROXY_PORT,
     });
+
     proxyScheme = items[PROXY_SCHEME];
     proxyHost = items[PROXY_HOST];
     proxyPort = items[PROXY_PORT];
     proxyAddress = `${proxyScheme}://${proxyHost}:${proxyPort}`;
+}
 
+/**
+ * Loads and populates the {@link proxyScheme}, {@link proxyHost}, {@link proxyPort}, and therefore the {@link proxyAddress}
+ * and updates the configuration itself via {@link updateProxyConfiguration}.
+ *
+ * If no update of the proxy configuration is desired, consider {@link loadProxySettingsNoUpdate}.
+ */
+export async function loadProxySettings() {
+    await loadProxySettingsNoUpdate();
     await updateProxyConfiguration();
 }
 
@@ -102,6 +121,10 @@ function isValidPort(port: string) {
 }
 
 async function fetchAndApplyScionPAC() {
+    // temporarily removing all rules to allow all requests performed during proxy-search
+    const anyRuleIsEnforced = GlobalStrictMode || Object.keys(PerSiteStrictMode).length > 0;
+    if (anyRuleIsEnforced) await removeAllRules();
+
     try {
         const response = await fetch(WPAD_URL);
         if (!response.ok) {
@@ -143,6 +166,9 @@ async function fetchAndApplyScionPAC() {
         console.warn("Error on WPAD process, falling back to default:", error);
         await fallbackToDefaults();
     }
+
+    // reset the rules based on the values stored in storage
+    if (anyRuleIsEnforced) await globalStrictModeUpdated();
 }
 
 async function fallbackToDefaults() {

--- a/chrome/background_helpers/request_interception_handler.ts
+++ b/chrome/background_helpers/request_interception_handler.ts
@@ -1,8 +1,10 @@
-import {proxyAddress, proxyHostResolveParam, proxyHostResolvePath, proxyURLResolvePath} from "./proxy_handler.js";
+import {DEFAULT_PROXY_HOST, proxyAddress, proxyHostResolveParam, proxyHostResolvePath, proxyURLResolvePath} from "./proxy_handler.js";
 import {addDnrRule} from "./dnr_handler.js";
 import {policyCookie} from "./geofence_handler.js";
-import {addRequest, addTabResource, clearTabResources, DOMAIN, getRequests, MAIN_DOMAIN, SCION_ENABLED, type RequestSchema} from "../shared/storage.js";
+import {addOrUpdateRequestInDB, DOMAIN, findRequestInDB, MAIN_DOMAIN, type RequestSchema, SCION_ENABLED} from "../shared/database.js";
+import {addTabResource, clearTabResources} from "../shared/storage.js";
 import {GlobalStrictMode, PerSiteStrictMode, normalizedHostname, safeHostname} from "../shared/utilities.js";
+
 type WebNavigationTransitionCallbackDetails = chrome.webNavigation.WebNavigationTransitionCallbackDetails;
 type OnBeforeRequestDetails = chrome.webRequest.OnBeforeRequestDetails;
 type OnHeadersReceivedDetails = chrome.webRequest.OnHeadersReceivedDetails;
@@ -28,7 +30,13 @@ export function initializeRequestInterceptionListeners() {
     chrome.webNavigation.onCommitted.addListener(onCommitted);
 }
 
-export async function isHostScion(hostname: string, initiator: string, currentTabId: number, alreadyHasLock = false) {
+/**
+ * Verifies and returns whether the specified {@link hostname} is SCION-capable.
+ *
+ * Contrary to {@link isHostScionHandleDnrRule}, this function does not add any DNR rules, it does
+ * however create an entry in storage via {@link createRequestEntry}.
+ */
+export async function isHostScion(hostname: string, initiator: string, currentTabId: number) {
     let scionEnabled = false;
 
     const fetchUrl = `${proxyAddress}${proxyHostResolvePath}?${proxyHostResolveParam}=${hostname}`;
@@ -43,13 +51,22 @@ export async function isHostScion(hostname: string, initiator: string, currentTa
         if (scionEnabled) console.log("[DB]: scion enabled (after resolve): ", hostname);
         else console.log("[DB]: scion disabled (after resolve): ", hostname);
 
-        await handleAddDnrRule(hostname, scionEnabled, alreadyHasLock);
         await createRequestEntry(hostname, initiator, currentTabId, scionEnabled);
     } else {
         console.warn("[DB]: Resolution error: ", response.status);
     }
 
     console.log("[DB]: Resolution returned that host is scion-capable: ", scionEnabled);
+    return scionEnabled;
+}
+
+/**
+ * Verifies and returns whether the host is scion via {@link isHostScion}. Additionally, conditionally
+ * adds a DNR rule via {@link handleAddDnrRule}.
+ */
+export async function isHostScionHandleDnrRule(hostname: string, initiator: string, currentTabId: number, alreadyHasLock = false) {
+    const scionEnabled = await isHostScion(hostname, initiator, currentTabId);
+    await handleAddDnrRule(hostname, scionEnabled, alreadyHasLock);
     return scionEnabled;
 }
 
@@ -69,8 +86,15 @@ function withTabLock(tabId: number, fn: (() => Promise<void>)) {
     return next;
 }
 
-// map that maps the tabId to a state (of type: { gen, topOrigin, currentDocumentId }
-const tabState = new Map();
+// primarily use documentId, use requestOrigin as a fallback option
+const REQUEST_ORIGIN = "requestOrigin" as const;
+const DOCUMENT_ID = "documentId" as const;
+type State = {
+    [REQUEST_ORIGIN]: string | null;
+    [DOCUMENT_ID]: string | null;
+}
+
+const tabState = new Map<number, State>();
 
 /**
  * Returns the hostname of the provided `url` in punycode format.
@@ -111,11 +135,9 @@ function onCommitted(details: WebNavigationTransitionCallbackDetails) {
     if (details.frameId !== 0) return;
 
     withTabLock(details.tabId, async () => {
-        const state = tabState.get(details.tabId) ?? {gen: 0, topOrigin: null, currentDocId: null};
         tabState.set(details.tabId, {
-            ...state,
-            topOrigin: safeOrigin(details.url),
-            currentDocId: details.documentId ?? null,
+            [REQUEST_ORIGIN]: safeOrigin(details.url),
+            [DOCUMENT_ID]: details.documentId ?? null,
         });
     });
 }
@@ -126,19 +148,22 @@ function onCommitted(details: WebNavigationTransitionCallbackDetails) {
  * - when strict mode is on and the host of the request is already known to the extension
  */
 function onBeforeRequest(details: OnBeforeRequestDetails): undefined {
+    const hostname = safeProtocolFilteredHostname(details.url);
+    if (!hostname || hostname.includes(DEFAULT_PROXY_HOST)) return;
+
     const tabId = details.tabId;
     if (tabId === chrome.tabs.TAB_ID_NONE || tabId < 0) return;
 
-    const hostname = safeProtocolFilteredHostname(details.url);
-    if (!hostname) return;
+    const initiator = details.initiator;
+    const initiatorOrigin = initiator ? safeOrigin(initiator) : null;
 
     withTabLock(tabId, async () => {
-        let state = tabState.get(tabId) ?? {gen: 0, topOrigin: null, currentDocId: null};
-
         // if a mainframe is detected, immediately reset the tab resources (since a new page was opened in an existing tab,
         // thus previous information should be removed)
         if (details.type === "main_frame") {
-            state = {gen: state.gen + 1, topOrigin: safeOrigin(details.url), currentDocId: null};
+            // in chrome, documentId is only present in requests to sub-resources when in onBeforeRequest, onCommitted however
+            // does contain a documentId for main-frame requests
+            const state = {[REQUEST_ORIGIN]: safeOrigin(details.url), [DOCUMENT_ID]: null};
             tabState.set(tabId, state);
             // if global strict mode is on, clearing resources is handled by checking.html
             if (!GlobalStrictMode) await clearTabResources(tabId);
@@ -152,32 +177,33 @@ function onBeforeRequest(details: OnBeforeRequestDetails): undefined {
             return;
         }
 
+        const state = tabState.get(tabId) ?? {[REQUEST_ORIGIN]: null, [DOCUMENT_ID]: null};
+
         // ignore requests if the documentId does not match the one observed in onCommitted
         // If the case (was never the case in testing) should occur where onCommitted is invoked after a subresource
         // invokes onBeforeRequest, it is currently ignored. A future fix would be keep a buffer of non-matching requests.
         // Due to results from testing and simplicity (since this is purely for UI information), it was left out for now.
-        const docId = details.documentId ?? null;
-        const currentDocId = state.currentDocId;
+        const docId = details.documentId;
+        const currentDocId = state[DOCUMENT_ID];
 
         // note that the two following if-statements are intentionally left empty for improved structure/documentation
         if (currentDocId && docId && docId === currentDocId) {
             // accept and handle request if the documentId matches the committed documentId stored in the state
-        } else if (currentDocId && !docId && state.topOrigin && details.initiator === state.topOrigin) {
+        } else if (currentDocId && !docId && state[REQUEST_ORIGIN] && initiatorOrigin === state[REQUEST_ORIGIN]) {
             // fallback solution in case a request does not contain a documentId at all:
             // if the initiator matches the url that was present in the onCommitted call of the mainframe, that is
             // also accepted and handled
         } else {
             // reject cases where the documentId and initiator do not match
-            console.log("[onBeforeRequest]: Seems to be a request unrelated to the current tab: ", details);
+            console.log("[onBeforeRequest]: Seems to be a request unrelated to the current tab: ", details, state);
             return;
         }
 
         // ===== CREATE TAB RESOURCES ENTRY =====
-        const requests = await getRequests();
-        const hostnameScionEnabled = requests.find((request) => request.domain === hostname)?.scionEnabled;
+        const hostnameScionEnabled = (await findRequestInDB(hostname))?.scionEnabled;
 
         // mainframe requests are already handled above and cannot reach this code, thus it is safe to assume that initiator exists
-        const initiatorHostname = safeHostname(details.initiator!);
+        const initiatorHostname = safeHostname(initiator!);
         if (initiatorHostname === null) {
             console.error("[onBeforeRequest]: Failed to extract hostname from initiator in: ", details);
             return;
@@ -203,7 +229,7 @@ function onBeforeRequest(details: OnBeforeRequestDetails): undefined {
                 console.log(`[onBeforeRequest]: Strict mode disabled, host '${hostname}' is unknown, lookup is performed.`);
 
                 // perform a lookup for the host, if it has not been discovered previously and strict mode is off
-                await isHostScion(hostname, initiatorHostname ?? hostname, tabId);
+                await isHostScionHandleDnrRule(hostname, initiatorHostname ?? hostname, tabId);
                 return;
             }
 
@@ -292,11 +318,7 @@ async function createRequestEntry(hostname: string, initiator: string, currentTa
         [SCION_ENABLED]: scionEnabled,
     };
 
-    await addRequest(requestDBEntry, {
-        [DOMAIN]: requestDBEntry[DOMAIN],
-        [MAIN_DOMAIN]: requestDBEntry[MAIN_DOMAIN],
-        [SCION_ENABLED]: requestDBEntry[SCION_ENABLED],
-    });
+    await addOrUpdateRequestInDB(requestDBEntry);
 
     if (currentTabId !== chrome.tabs.TAB_ID_NONE) await addTabResource(currentTabId, hostname, scionEnabled);
 }
@@ -307,7 +329,7 @@ async function createRequestEntry(hostname: string, initiator: string, currentTa
  */
 async function handleAddDnrRule(hostname: string, scionEnabled: boolean, alreadyHasLock: boolean) {
     const strictHosts = Object.entries(PerSiteStrictMode)
-        .filter(([_, isScion]: [string, boolean]) => isScion)
+        .filter(([_, isEnabled]: [string, boolean]) => isEnabled)
         .map(([host, _]: [string, boolean]) => normalizedHostname(host));
 
     if (GlobalStrictMode || strictHosts.includes(hostname)) {

--- a/chrome/background_helpers/request_interception_handler.ts
+++ b/chrome/background_helpers/request_interception_handler.ts
@@ -2,8 +2,7 @@ import {proxyAddress, proxyHostResolveParam, proxyHostResolvePath, proxyURLResol
 import {addDnrRule} from "./dnr_handler.js";
 import {policyCookie} from "./geofence_handler.js";
 import {addRequest, addTabResource, clearTabResources, DOMAIN, getRequests, MAIN_DOMAIN, SCION_ENABLED, type RequestSchema} from "../shared/storage.js";
-import {normalizedHostname, safeHostname} from "../shared/utilities.js";
-import {GlobalStrictMode, PerSiteStrictMode} from "../background.js";
+import {GlobalStrictMode, PerSiteStrictMode, normalizedHostname, safeHostname} from "../shared/utilities.js";
 type WebNavigationTransitionCallbackDetails = chrome.webNavigation.WebNavigationTransitionCallbackDetails;
 type OnBeforeRequestDetails = chrome.webRequest.OnBeforeRequestDetails;
 type OnHeadersReceivedDetails = chrome.webRequest.OnHeadersReceivedDetails;

--- a/chrome/background_helpers/tab_handler.ts
+++ b/chrome/background_helpers/tab_handler.ts
@@ -1,5 +1,6 @@
 import {clearAllTabResources, clearTabResources, getTabResources} from "../shared/storage.js";
 import {safeHostname} from "../shared/utilities.js";
+
 type Tab = chrome.tabs.Tab;
 
 export function initializeTabListeners() {
@@ -56,11 +57,10 @@ export async function handleTabChange(tab: Tab) {
         }
 
         if (mainDomainSCIONEnabled) {
-            if (mixedContent) {
+            if (mixedContent)
                 await chrome.action.setIcon({path: "/images/scion-38_mixed.jpg"});
-            } else {
+            else
                 await chrome.action.setIcon({path: "/images/scion-38_enabled.jpg"});
-            }
         } else {
             await chrome.action.setIcon({path: "/images/scion-38_not_available.jpg"});
         }

--- a/chrome/checking.ts
+++ b/chrome/checking.ts
@@ -1,7 +1,7 @@
 import {isHostScionHandleDnrRule} from "./background_helpers/request_interception_handler.js";
 import {clearTabResources} from "./shared/storage.js";
 import {initializeStrictModes, safeHostname} from "./shared/utilities.js";
-import {initializeProxyHandler} from "./background_helpers/proxy_handler.js";
+import {loadProxySettings} from "./background_helpers/proxy_handler.js";
 
 const titleElement = document.getElementById("title") as HTMLHeadingElement;
 const spinnerElement = document.getElementById("spinner") as HTMLDivElement;
@@ -10,7 +10,7 @@ const originalUrlElement = document.getElementById('original-url') as HTMLParagr
 
 async function init() {
     await initializeStrictModes();
-    await initializeProxyHandler();
+    await loadProxySettings();
 
     statusElement.textContent = 'Determining the original page you tried to open...';
 

--- a/chrome/checking.ts
+++ b/chrome/checking.ts
@@ -1,7 +1,7 @@
 import {isHostScionHandleDnrRule} from "./background_helpers/request_interception_handler.js";
 import {clearTabResources} from "./shared/storage.js";
 import {initializeStrictModes, safeHostname} from "./shared/utilities.js";
-import {loadProxySettings} from "./background_helpers/proxy_handler.js";
+import {loadProxySettingsNoUpdate} from "./background_helpers/proxy_handler.js";
 
 const titleElement = document.getElementById("title") as HTMLHeadingElement;
 const spinnerElement = document.getElementById("spinner") as HTMLDivElement;
@@ -10,7 +10,7 @@ const originalUrlElement = document.getElementById('original-url') as HTMLParagr
 
 async function init() {
     await initializeStrictModes();
-    await loadProxySettings();
+    await loadProxySettingsNoUpdate();
 
     statusElement.textContent = 'Determining the original page you tried to open...';
 

--- a/chrome/checking.ts
+++ b/chrome/checking.ts
@@ -1,6 +1,6 @@
-import {isHostScion} from "./background_helpers/request_interception_handler.js";
+import {isHostScionHandleDnrRule} from "./background_helpers/request_interception_handler.js";
 import {clearTabResources} from "./shared/storage.js";
-import {safeHostname} from "./shared/utilities.js";
+import {initializeStrictModes, safeHostname} from "./shared/utilities.js";
 import {initializeProxyHandler} from "./background_helpers/proxy_handler.js";
 
 const titleElement = document.getElementById("title") as HTMLHeadingElement;
@@ -9,6 +9,7 @@ const statusElement = document.getElementById('status') as HTMLParagraphElement;
 const originalUrlElement = document.getElementById('original-url') as HTMLParagraphElement;
 
 async function init() {
+    await initializeStrictModes();
     await initializeProxyHandler();
 
     statusElement.textContent = 'Determining the original page you tried to open...';
@@ -46,7 +47,7 @@ async function init() {
     // clearing the resources must be done here, as onBeforeRequest only handles it in non-globalStrictMode, this is in order
     // not to clear tab resources added via the isHostScion call below
     if (currentTab.id && currentTab.id >= 0) await clearTabResources(currentTab.id);
-    const isScion = await isHostScion(host, host, currentTab.id !== undefined ? currentTab.id : chrome.tabs.TAB_ID_NONE);
+    const isScion = await isHostScionHandleDnrRule(host, host, currentTab.id !== undefined ? currentTab.id : chrome.tabs.TAB_ID_NONE);
     if (!isScion) {
         statusElement.textContent = "This page is NOT SCION-capable and was blocked in strict mode.";
         checkFinished()

--- a/chrome/options.ts
+++ b/chrome/options.ts
@@ -8,7 +8,6 @@
 import {
     AUTO_PROXY_CONFIG,
     getSyncValue,
-    getSyncValues,
     GLOBAL_STRICT_MODE,
     ISD_ALL,
     ISD_WHITELIST,
@@ -19,8 +18,17 @@ import {
     saveSyncValue,
     saveSyncValues
 } from "./shared/storage.js";
-import {DEFAULT_PROXY_HOST, HTTPS_PROXY_PORT, HTTPS_PROXY_SCHEME, type OnMessageMessageType} from "./background_helpers/proxy_handler.js";
-import {initializeStrictModes} from "./shared/utilities.js";
+import {
+    DEFAULT_PROXY_HOST,
+    HTTPS_PROXY_PORT,
+    HTTPS_PROXY_SCHEME,
+    loadProxySettingsNoUpdate,
+    type OnMessageMessageType,
+    proxyHost,
+    proxyPort,
+    proxyScheme
+} from "./background_helpers/proxy_handler.js";
+import {GlobalStrictMode, initializeStrictModes} from "./shared/utilities.js";
 
 const DEFAULT_PROXY_SCHEME = HTTPS_PROXY_SCHEME;
 const DEFAULT_PROXY_PORT = HTTPS_PROXY_PORT;
@@ -58,8 +66,16 @@ const tableSitePreferencesRow = `
 
 const placeholderToggleID = "toggleISD-";
 
-initializeStrictModes();
 document.addEventListener("DOMContentLoaded", async () => {
+    await initializeStrictModes();
+
+    toggleGlobalStrict.checked = GlobalStrictMode;
+    if (toggleGlobalStrict.checked) {
+        lineStrictMode.style.backgroundColor = '#48bb78';
+    } else {
+        lineStrictMode.style.backgroundColor = '#cccccc';
+    }
+
     const isdSet = await getSyncValue(ISD_WHITELIST, []);
     displayToggleISD(isdSet);
 
@@ -68,6 +84,24 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     registerToggleISDHandler();
     registerToggleAllHandler();
+
+    // Load saved settings
+    await loadProxySettingsNoUpdate();
+    proxySchemeElement.value = proxyScheme;
+    proxyHostElement.value = proxyHost;
+    proxyPortElement.value = proxyPort;
+
+    const saveProxySettingsButton = document.getElementById('save-proxy-settings') as HTMLButtonElement;
+    const resetProxyDefaultsButton = document.getElementById('reset-proxy-defaults') as HTMLButtonElement;
+    const autoProxyConfigInput = document.getElementById('auto-proxy-config') as HTMLInputElement;
+
+    const autoProxyConfig = await getSyncValue(AUTO_PROXY_CONFIG, true);
+    autoProxyConfigInput.checked = autoProxyConfig;
+    updateProxyFormState(autoProxyConfig);
+
+    saveProxySettingsButton.addEventListener('click', saveProxySettings);
+    resetProxyDefaultsButton.addEventListener('click', resetProxyDefaults);
+    autoProxyConfigInput.addEventListener('change', saveAutoProxyConfig);
 });
 
 function displayToggleISD(isdSet: string[]) {
@@ -161,17 +195,9 @@ function toggleGlobalStrictMode() {
     } else {
         lineStrictMode.style.backgroundColor = '#cccccc';
     }
+
     saveSyncValue(GLOBAL_STRICT_MODE, toggleGlobalStrict.checked);
 }
-
-getSyncValue(GLOBAL_STRICT_MODE, false).then(globalStrictMode => {
-    toggleGlobalStrict.checked = globalStrictMode;
-    if (toggleGlobalStrict.checked) {
-        lineStrictMode.style.backgroundColor = '#48bb78';
-    } else {
-        lineStrictMode.style.backgroundColor = '#cccccc';
-    }
-});
 
 function updateSitePreferences() {
     getSyncValue(PER_SITE_STRICT_MODE, {}).then(perSiteStrictMode => {
@@ -264,31 +290,6 @@ function updateProxyFormState(isAutoConfig: boolean) {
         chrome.runtime.sendMessage(message);
     }
 }
-
-// Load saved settings
-document.addEventListener('DOMContentLoaded', function() {
-    getSyncValues({
-        [PROXY_SCHEME]: "https",
-        [PROXY_HOST]: "forward-proxy.scion",
-        [PROXY_PORT]: "9443",
-    }).then((items) => {
-        proxySchemeElement.value = items[PROXY_SCHEME];
-        proxyHostElement.value = items[PROXY_HOST];
-        proxyPortElement.value = items[PROXY_PORT];
-    });
-
-    const saveProxySettingsButton = document.getElementById('save-proxy-settings') as HTMLButtonElement;
-    const resetProxyDefaultsButton = document.getElementById('reset-proxy-defaults') as HTMLButtonElement;
-    const autoProxyConfigInput = document.getElementById('auto-proxy-config') as HTMLInputElement;
-    getSyncValue(AUTO_PROXY_CONFIG, true).then(autoProxyConfig => {
-        autoProxyConfigInput.checked = autoProxyConfig;
-        updateProxyFormState(autoProxyConfig);
-    });
-
-    saveProxySettingsButton.addEventListener('click', saveProxySettings);
-    resetProxyDefaultsButton.addEventListener('click', resetProxyDefaults);
-    autoProxyConfigInput.addEventListener('change', saveAutoProxyConfig);
-});
   
 function saveProxySettings() {
     const scheme = proxySchemeElement.value;

--- a/chrome/options.ts
+++ b/chrome/options.ts
@@ -19,7 +19,8 @@ import {
     saveSyncValue,
     saveSyncValues
 } from "./shared/storage.js";
-import {DEFAULT_PROXY_HOST, HTTPS_PROXY_PORT, HTTPS_PROXY_SCHEME} from "./background_helpers/proxy_handler.js";
+import {DEFAULT_PROXY_HOST, HTTPS_PROXY_PORT, HTTPS_PROXY_SCHEME, type OnMessageMessageType} from "./background_helpers/proxy_handler.js";
+import {initializeStrictModes} from "./shared/utilities.js";
 
 const DEFAULT_PROXY_SCHEME = HTTPS_PROXY_SCHEME;
 const DEFAULT_PROXY_PORT = HTTPS_PROXY_PORT;
@@ -57,6 +58,7 @@ const tableSitePreferencesRow = `
 
 const placeholderToggleID = "toggleISD-";
 
+initializeStrictModes();
 document.addEventListener("DOMContentLoaded", async () => {
     const isdSet = await getSyncValue(ISD_WHITELIST, []);
     displayToggleISD(isdSet);
@@ -258,7 +260,8 @@ function updateProxyFormState(isAutoConfig: boolean) {
     });
     
     if (isAutoConfig) {
-      chrome.runtime.sendMessage({ action: "fetchAndApplyScionPAC" });
+        const message = { action: "fetchAndApplyScionPAC"} as OnMessageMessageType;
+        chrome.runtime.sendMessage(message);
     }
 }
 

--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -17,9 +17,9 @@
             </div>
             <div class="flex flex-col" style="width: 95px;" class="items-center">
                 <!-- toggle -->
-                <div class="relative" id="checkboxRunning" style="margin: auto;">
+                <div class="relative" id="togglePerSiteStrictModeContainer" style="margin: auto;">
                     <!-- input -->
-                    <input id="toggleRunning" type="checkbox" class="sr-only" onchange="toggleExtensionRunning();" />
+                    <input id="togglePerSiteStrictMode" type="checkbox" class="sr-only"/>
                     <!-- line -->
                     <div id="lineRunning" class="w-8 h-5 bg-gray-400 rounded-full shadow-inner"></div>
                     <!-- dot -->

--- a/chrome/popup.ts
+++ b/chrome/popup.ts
@@ -2,9 +2,9 @@
 'use strict';
 
 
-import {getSyncValue, getSyncValues, getTabResources, PER_SITE_STRICT_MODE, PROXY_HOST, PROXY_PORT, PROXY_SCHEME, saveSyncValue, type SyncValueSchema} from "./shared/storage.js";
-import {DEFAULT_PROXY_HOST, HTTPS_PROXY_SCHEME, HTTPS_PROXY_PORT, proxyPathUsagePath, proxyHealthCheckPath} from "./background_helpers/proxy_handler.js";
-import {safeHostname} from "./shared/utilities.js";
+import {getSyncValues, getTabResources, PER_SITE_STRICT_MODE, PROXY_HOST, PROXY_PORT, PROXY_SCHEME, saveSyncValue} from "./shared/storage.js";
+import {DEFAULT_PROXY_HOST, HTTPS_PROXY_PORT, HTTPS_PROXY_SCHEME, proxyHealthCheckPath, proxyPathUsagePath} from "./background_helpers/proxy_handler.js";
+import {initializeStrictModes, PerSiteStrictMode, safeHostname, setPerSiteStrictMode} from "./shared/utilities.js";
 
 type Tab = chrome.tabs.Tab;
 type PerDomainPathUsage = { Domain: string, Path: string[], Strategy: string };
@@ -403,7 +403,6 @@ const asNameMap: Record<string, string> = {
 let proxyAddress = `${DEFAULT_PROXY_SCHEME}://${DEFAULT_PROXY_HOST}:${DEFAULT_PROXY_PORT}`
 
 
-let perSiteStrictMode: SyncValueSchema[typeof PER_SITE_STRICT_MODE] = {};
 let popupMainDomain = "";
 
 checkboxRunning.onclick = toggleExtensionRunning;
@@ -412,10 +411,7 @@ buttonOptionsButton.addEventListener('click', function () {
     chrome.tabs.create({'url': 'chrome://extensions/?options=' + chrome.runtime.id});
 });
 
-getSyncValue(PER_SITE_STRICT_MODE, {}).then((result) => {
-    perSiteStrictMode = result;
-    loadRequestInfo();
-});
+initializeStrictModes();
 
 document.addEventListener("DOMContentLoaded", () => {
     getSyncValues({
@@ -632,7 +628,7 @@ function returnCountryCode(isd: number) {
 function toggleExtensionRunning() {
     toggleRunning.checked = !toggleRunning.checked;
     const newPerSiteStrictMode = {
-        ...perSiteStrictMode,
+        ...PerSiteStrictMode,
         [popupMainDomain]: toggleRunning.checked,
     };
 
@@ -647,9 +643,8 @@ function toggleExtensionRunning() {
     }
 
     saveSyncValue(PER_SITE_STRICT_MODE, newPerSiteStrictMode).then(() => {
-        perSiteStrictMode = newPerSiteStrictMode;
+        setPerSiteStrictMode(newPerSiteStrictMode);
     });
-
 }
 
 async function loadRequestInfo() {
@@ -676,7 +671,7 @@ async function loadRequestInfo() {
     const resources = await getTabResources(activeTabId) ?? [];
     const mainDomainSCIONEnabled = resources.find(resource => resource[0] === hostname && resource[1]);
 
-    if (perSiteStrictMode[hostname]) {
+    if (PerSiteStrictMode[hostname]) {
         mainDomain.innerHTML = "SCION preference for " + hostname;
         toggleRunning.checked = true; // true
         toggleRunning.classList.remove("halfchecked");

--- a/chrome/popup.ts
+++ b/chrome/popup.ts
@@ -13,8 +13,8 @@ type ProxyPathUsageResponse = PerDomainPathUsage[];
 const DEFAULT_PROXY_SCHEME = HTTPS_PROXY_SCHEME;
 const DEFAULT_PROXY_PORT = HTTPS_PROXY_PORT;
 
-const toggleRunning = document.getElementById('toggleRunning') as HTMLInputElement;
-const checkboxRunning = document.getElementById('checkboxRunning') as HTMLDivElement;
+const togglePerSiteStrictModeCheckbox = document.getElementById('togglePerSiteStrictMode') as HTMLInputElement;
+const togglePerSiteStrictModeContainer = document.getElementById('togglePerSiteStrictModeContainer') as HTMLDivElement;
 const lineRunning = document.getElementById("lineRunning") as HTMLDivElement;
 const scionmode = document.getElementById("scionmode") as HTMLSpanElement;
 const mainDomain = document.getElementById("maindomain") as HTMLDivElement;
@@ -405,7 +405,7 @@ let proxyAddress = `${DEFAULT_PROXY_SCHEME}://${DEFAULT_PROXY_HOST}:${DEFAULT_PR
 
 let popupMainDomain = "";
 
-checkboxRunning.onclick = toggleExtensionRunning;
+togglePerSiteStrictModeContainer.onclick = togglePerSiteStrictMode;
 
 buttonOptionsButton.addEventListener('click', function () {
     chrome.tabs.create({'url': 'chrome://extensions/?options=' + chrome.runtime.id});
@@ -413,19 +413,20 @@ buttonOptionsButton.addEventListener('click', function () {
 
 initializeStrictModes();
 
-document.addEventListener("DOMContentLoaded", () => {
-    getSyncValues({
+document.addEventListener("DOMContentLoaded", async () => {
+    togglePerSiteStrictModeCheckbox.addEventListener("change", togglePerSiteStrictMode);
+    const result = await getSyncValues({
         [PROXY_SCHEME]: DEFAULT_PROXY_SCHEME,
         [PROXY_HOST]: DEFAULT_PROXY_HOST,
         [PROXY_PORT]: DEFAULT_PROXY_PORT,
-    }).then((result) => {
-        let proxyScheme = result[PROXY_SCHEME];
-        let proxyHost = result[PROXY_HOST];
-        let proxyPort = result[PROXY_PORT];
-        proxyAddress = `${proxyScheme}://${proxyHost}:${proxyPort}`;
-
-        checkProxyStatus();
     });
+
+    let proxyScheme = result[PROXY_SCHEME];
+    let proxyHost = result[PROXY_HOST];
+    let proxyPort = result[PROXY_PORT];
+    proxyAddress = `${proxyScheme}://${proxyHost}:${proxyPort}`;
+
+    checkProxyStatus();
 });
 
 const updatePathUsage = () => {
@@ -625,14 +626,14 @@ function returnCountryCode(isd: number) {
 }
 
 // Start/Stop global forwarding
-function toggleExtensionRunning() {
-    toggleRunning.checked = !toggleRunning.checked;
+function togglePerSiteStrictMode() {
+    togglePerSiteStrictModeCheckbox.checked = !togglePerSiteStrictModeCheckbox.checked;
     const newPerSiteStrictMode = {
         ...PerSiteStrictMode,
-        [popupMainDomain]: toggleRunning.checked,
+        [popupMainDomain]: togglePerSiteStrictModeCheckbox.checked,
     };
 
-    if (toggleRunning.checked) {
+    if (togglePerSiteStrictModeCheckbox.checked) {
         mainDomain.innerHTML = "SCION preference for " + popupMainDomain;
         lineRunning.style.backgroundColor = "#48bb78";
         scionmode.innerHTML = "Strict";
@@ -673,19 +674,19 @@ async function loadRequestInfo() {
 
     if (PerSiteStrictMode[hostname]) {
         mainDomain.innerHTML = "SCION preference for " + hostname;
-        toggleRunning.checked = true; // true
-        toggleRunning.classList.remove("halfchecked");
+        togglePerSiteStrictModeCheckbox.checked = true; // true
+        togglePerSiteStrictModeCheckbox.classList.remove("halfchecked");
         lineRunning.style.backgroundColor = "#48bb78";
         scionmode.innerHTML = "Strict";
     } else if (mainDomainSCIONEnabled) {
         mainDomain.innerHTML = "SCION preference for " + hostname;
-        toggleRunning.checked = false; // true
-        toggleRunning.classList.add("halfchecked");
+        togglePerSiteStrictModeCheckbox.checked = false; // true
+        togglePerSiteStrictModeCheckbox.classList.add("halfchecked");
         lineRunning.style.backgroundColor = "#cccccc";
         scionmode.innerHTML = "When available";
     } else {
         scionModePreference.style.display = "none";
-    }// TODO: Else case would be no SCION... toggleRunning.checked = false;
+    }// TODO: Else case would be no SCION... togglePerSiteStrictModeCheckbox.checked = false;
 
     let mixedContent = false
     for (const resource of resources) {

--- a/chrome/popup.ts
+++ b/chrome/popup.ts
@@ -2,16 +2,13 @@
 'use strict';
 
 
-import {getSyncValues, getTabResources, PER_SITE_STRICT_MODE, PROXY_HOST, PROXY_PORT, PROXY_SCHEME, saveSyncValue} from "./shared/storage.js";
-import {DEFAULT_PROXY_HOST, HTTPS_PROXY_PORT, HTTPS_PROXY_SCHEME, proxyHealthCheckPath, proxyPathUsagePath} from "./background_helpers/proxy_handler.js";
+import {getTabResources, PER_SITE_STRICT_MODE, saveSyncValue} from "./shared/storage.js";
+import {loadProxySettingsNoUpdate, proxyAddress, proxyHealthCheckPath, proxyPathUsagePath} from "./background_helpers/proxy_handler.js";
 import {initializeStrictModes, PerSiteStrictMode, safeHostname, setPerSiteStrictMode} from "./shared/utilities.js";
 
 type Tab = chrome.tabs.Tab;
 type PerDomainPathUsage = { Domain: string, Path: string[], Strategy: string };
 type ProxyPathUsageResponse = PerDomainPathUsage[];
-
-const DEFAULT_PROXY_SCHEME = HTTPS_PROXY_SCHEME;
-const DEFAULT_PROXY_PORT = HTTPS_PROXY_PORT;
 
 const togglePerSiteStrictModeCheckbox = document.getElementById('togglePerSiteStrictMode') as HTMLInputElement;
 const togglePerSiteStrictModeContainer = document.getElementById('togglePerSiteStrictModeContainer') as HTMLDivElement;
@@ -400,68 +397,21 @@ const asNameMap: Record<string, string> = {
     "2:0:138": "IKEA AG"
 };
 
-let proxyAddress = `${DEFAULT_PROXY_SCHEME}://${DEFAULT_PROXY_HOST}:${DEFAULT_PROXY_PORT}`
-
-
 let popupMainDomain = "";
 
-togglePerSiteStrictModeContainer.onclick = togglePerSiteStrictMode;
-
-buttonOptionsButton.addEventListener('click', function () {
-    chrome.tabs.create({'url': 'chrome://extensions/?options=' + chrome.runtime.id});
-});
-
-initializeStrictModes();
-
 document.addEventListener("DOMContentLoaded", async () => {
-    togglePerSiteStrictModeCheckbox.addEventListener("change", togglePerSiteStrictMode);
-    const result = await getSyncValues({
-        [PROXY_SCHEME]: DEFAULT_PROXY_SCHEME,
-        [PROXY_HOST]: DEFAULT_PROXY_HOST,
-        [PROXY_PORT]: DEFAULT_PROXY_PORT,
-    });
+    await initializeStrictModes();
+    await loadProxySettingsNoUpdate();
+    await loadRequestInfo();
 
-    let proxyScheme = result[PROXY_SCHEME];
-    let proxyHost = result[PROXY_HOST];
-    let proxyPort = result[PROXY_PORT];
-    proxyAddress = `${proxyScheme}://${proxyHost}:${proxyPort}`;
+    togglePerSiteStrictModeCheckbox.addEventListener("change", togglePerSiteStrictMode);
+    togglePerSiteStrictModeContainer.onclick = togglePerSiteStrictMode;
+    buttonOptionsButton.addEventListener('click', function () {
+        chrome.tabs.create({'url': 'chrome://extensions/?options=' + chrome.runtime.id});
+    });
 
     checkProxyStatus();
 });
-
-const updatePathUsage = () => {
-    pathUsageContainer.innerHTML = "";
-
-    console.log("get path usage")
-    fetch(`${proxyAddress}${proxyPathUsagePath}`, {
-        method: "GET"
-    }).then(response => {
-        if (response.status === 200) {
-            response.json().then(res => {
-                const json = res as ProxyPathUsageResponse;
-                console.log(json)
-                const startIndex = 2; // The first indices are already used the parent container
-                if (!json || json.length === 0) {
-                    pathUsageContainer.innerHTML = "<p>No path usage data available\n</p>" + "<p>Try to configure your own policies to have acces to path usage data (under <i>Manage Preferences</i>).</p>";
-                }
-
-                json.forEach((pathUsage: PerDomainPathUsage) => {
-                    console.log(pathUsage.Domain.split(":")[0])
-                    // we only expect one match
-                    if (popupMainDomain && pathUsage.Domain.split(":")[0] === popupMainDomain) {
-                        let pathUsageChild = newPathUsageChild(pathUsage, startIndex);
-                        pathUsageContainer.innerHTML += pathUsageChild;
-                    }
-                })
-                if (pathUsageContainer.innerHTML === "") {
-                    pathUsageContainer.innerHTML = "<p>No path usage data available for " + (popupMainDomain || "current domain") + "\n</p>" + "<p>Try to configure your own policies to have acces to path usage data (under <i>Manage Preferences</i>).</p>";
-                    return;
-                }
-            });
-        }
-    });
-
-};
 
 function checkProxyStatus() {
     proxyStatusMessage.textContent = "Checking proxy status...";
@@ -718,4 +668,37 @@ async function loadRequestInfo() {
     // Update path usage for the current domain
     updatePathUsage();
 }
+
+const updatePathUsage = () => {
+    pathUsageContainer.innerHTML = "";
+
+    console.log("get path usage")
+    fetch(`${proxyAddress}${proxyPathUsagePath}`, {
+        method: "GET"
+    }).then(response => {
+        if (response.status === 200) {
+            response.json().then(res => {
+                const json = res as ProxyPathUsageResponse;
+                console.log(json)
+                const startIndex = 2; // The first indices are already used the parent container
+                if (!json || json.length === 0) {
+                    pathUsageContainer.innerHTML = "<p>No path usage data available\n</p>" + "<p>Try to configure your own policies to have acces to path usage data (under <i>Manage Preferences</i>).</p>";
+                }
+
+                json.forEach((pathUsage: PerDomainPathUsage) => {
+                    console.log(pathUsage.Domain.split(":")[0])
+                    // we only expect one match
+                    if (popupMainDomain && pathUsage.Domain.split(":")[0] === popupMainDomain) {
+                        let pathUsageChild = newPathUsageChild(pathUsage, startIndex);
+                        pathUsageContainer.innerHTML += pathUsageChild;
+                    }
+                })
+                if (pathUsageContainer.innerHTML === "") {
+                    pathUsageContainer.innerHTML = "<p>No path usage data available for " + (popupMainDomain || "current domain") + "\n</p>" + "<p>Try to configure your own policies to have acces to path usage data (under <i>Manage Preferences</i>).</p>";
+                    return;
+                }
+            });
+        }
+    });
+};
 

--- a/chrome/shared/database.ts
+++ b/chrome/shared/database.ts
@@ -93,7 +93,8 @@ export async function addOrUpdateRequestInDB(entry: RequestSchema): Promise<void
         lastAccessed: now(),
     };
 
-    store.put(newEntry);
+    const addOrUpdateRequest = store.put(newEntry);
+    await requestToPromise(addOrUpdateRequest);
 
     const count = await getEntryCount(store);
     if (count + 1 > MAX_ENTRIES) {
@@ -141,7 +142,8 @@ export async function findRequestInDB(domain: RequestSchema[typeof DOMAIN]): Pro
 
     // update the timestamp, as this entry was requested
     entry.lastAccessed = now();
-    store.put(entry);
+    const addOrUpdateRequest = store.put(entry);
+    await requestToPromise(addOrUpdateRequest);
 
     await transactionDone(transaction);
 
@@ -169,7 +171,7 @@ export async function evictExpiredEntries() {
     const req = index.openCursor();
 
     await new Promise<void>((resolve, reject) => {
-        req.onsuccess = () => {
+        req.onsuccess = async () => {
             const cursor = req.result as IDBCursorWithValue | null;
             if (!cursor) {
                 resolve();
@@ -184,7 +186,8 @@ export async function evictExpiredEntries() {
                 return;
             }
 
-            store.delete(cursor.primaryKey);
+            const deleteRequest = store.delete(cursor.primaryKey);
+            await requestToPromise(deleteRequest);
             cursor.continue();
         };
 
@@ -242,14 +245,15 @@ async function evictLRU(store: IDBObjectStore, count: number): Promise<void> {
     const req = index.openCursor(); // ascending TTL
 
     await new Promise<void>((resolve, reject) => {
-        req.onsuccess = () => {
+        req.onsuccess = async () => {
             const cursor = req.result;
             if (!cursor || removed >= count) {
                 resolve();
                 return;
             }
 
-            store.delete(cursor.primaryKey);
+            const deleteRequest = store.delete(cursor.primaryKey);
+            await requestToPromise(deleteRequest);
             removed++;
             cursor.continue();
         };
@@ -266,11 +270,8 @@ async function evictLRU(store: IDBObjectStore, count: number): Promise<void> {
  * here.
  */
 async function getEntryCount(store: IDBObjectStore): Promise<number> {
-    const request = store.count();
-    return await new Promise((resolve, reject) => {
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(request.error);
-    });
+    const countRequest = store.count();
+    return await requestToPromise(countRequest);
 }
 
 /**
@@ -292,5 +293,18 @@ function transactionDone(transaction: IDBTransaction): Promise<void> {
         transaction.oncomplete = () => resolve();
         transaction.onerror = () => reject(transaction.error);
         transaction.onabort = () => reject(transaction.error);
+    });
+}
+
+/**
+ * Converts an {@link IDBRequest} into an await-able {@link Promise}.
+ * @example
+ * const request = store.put(entry);
+ * await requestToPromise(request);
+ */
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
     });
 }

--- a/chrome/shared/database.ts
+++ b/chrome/shared/database.ts
@@ -97,7 +97,10 @@ export async function addOrUpdateRequestInDB(entry: RequestSchema): Promise<void
     await requestToPromise(addOrUpdateRequest);
 
     const count = await getEntryCount(store);
-    if (count + 1 > MAX_ENTRIES) {
+    // since MAX_ENTRIES already accounts for some buffer, concurrent changes to the DNR rules will
+    // with near certainty not exceed the DNR rule limit until rules are evicted, hence simply comparing
+    // count and not e.g. count+10 is sufficient
+    if (count > MAX_ENTRIES) {
         await evictLRU(store, EVICT_COUNT);
     }
 

--- a/chrome/shared/database.ts
+++ b/chrome/shared/database.ts
@@ -142,8 +142,7 @@ export async function findRequestInDB(domain: RequestSchema[typeof DOMAIN]): Pro
 
     // update the timestamp, as this entry was requested
     entry.lastAccessed = now();
-    const addOrUpdateRequest = store.put(entry);
-    await requestToPromise(addOrUpdateRequest);
+    store.put(entry);
 
     await transactionDone(transaction);
 
@@ -171,7 +170,7 @@ export async function evictExpiredEntries() {
     const req = index.openCursor();
 
     await new Promise<void>((resolve, reject) => {
-        req.onsuccess = async () => {
+        req.onsuccess = () => {
             const cursor = req.result as IDBCursorWithValue | null;
             if (!cursor) {
                 resolve();
@@ -186,8 +185,7 @@ export async function evictExpiredEntries() {
                 return;
             }
 
-            const deleteRequest = store.delete(cursor.primaryKey);
-            await requestToPromise(deleteRequest);
+            store.delete(cursor.primaryKey);
             cursor.continue();
         };
 
@@ -245,15 +243,14 @@ async function evictLRU(store: IDBObjectStore, count: number): Promise<void> {
     const req = index.openCursor(); // ascending TTL
 
     await new Promise<void>((resolve, reject) => {
-        req.onsuccess = async () => {
+        req.onsuccess = () => {
             const cursor = req.result;
             if (!cursor || removed >= count) {
                 resolve();
                 return;
             }
 
-            const deleteRequest = store.delete(cursor.primaryKey);
-            await requestToPromise(deleteRequest);
+            store.delete(cursor.primaryKey);
             removed++;
             cursor.continue();
         };

--- a/chrome/shared/database.ts
+++ b/chrome/shared/database.ts
@@ -1,0 +1,296 @@
+// NOTE: To inspect the IDB in Chromium-based browsers, go to an extension-page (e.g. options.html) and to the DevTools tab there (service worker does not show the IDB)
+// see https://groups.google.com/a/chromium.org/g/chromium-extensions/c/iMmV93LyNjI
+
+export const DOMAIN = "domain" as const;
+export const MAIN_DOMAIN = "mainDomain" as const;
+export const SCION_ENABLED = "scionEnabled" as const;
+
+export type RequestSchema = {
+    [DOMAIN]: string;
+    [MAIN_DOMAIN]: string;
+    [SCION_ENABLED]: boolean;
+};
+
+/**
+ * Extends the {@link RequestSchema} by the {@link key} and {@link lastAccessed} properties.
+ */
+type RequestEntryInternal = RequestSchema & {
+    key: string;
+    lastAccessed: number;
+};
+
+const DB_NAME = "scion-cache-db";
+const DB_VERSION = 1;
+
+const STORE_ENTRIES = "entries";
+
+const INDEX_LAST_ACCESSED = "by_lastAccessed";
+const INDEX_DOMAIN = "by_domain";
+
+const MAX_ENTRIES = chrome.declarativeNetRequest.MAX_NUMBER_OF_DYNAMIC_RULES - 500; // subtracting some buffer
+const EVICT_COUNT = 100; // arbitrary number that results in eviction process taking ~15ms
+/**
+ * Represents 1 week.
+ */
+const MAX_TIME_ALIVE = 7 * 24 * 60 * 60 * 1000;
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+/**
+ * Returns all entries stored in the DB.
+ *
+ * Note: This operation is slow (~1000ms for a DB with 30k entries). Use it appropriately.
+ */
+export async function getRequestsInDB(): Promise<RequestSchema[]> {
+    const db = await openDB();
+
+    const transaction = db.transaction(STORE_ENTRIES, "readonly");
+    const store = transaction.objectStore(STORE_ENTRIES);
+    const req = store.openCursor();
+
+    const result: RequestSchema[] = [];
+
+    await new Promise<void>((resolve, reject) => {
+        req.onsuccess = () => {
+            const cursor = req.result;
+            if (!cursor) {
+                resolve();
+                return;
+            }
+
+            const entry = cursor.value as RequestEntryInternal;
+            result.push({
+                [DOMAIN]: entry.domain,
+                [MAIN_DOMAIN]: entry.mainDomain,
+                [SCION_ENABLED]: entry.scionEnabled,
+            });
+
+            cursor.continue();
+        };
+        req.onerror = () => reject(req.error);
+    });
+
+    return result;
+}
+
+/**
+ * Adds or updates an entry in the DB.
+ *
+ * The {@link DOMAIN} and {@link MAIN_DOMAIN} are used
+ * as the key in the DB; if an entry already exists with this key, the {@link SCION_ENABLED} value is
+ * overwritten and {@link RequestEntryInternal.lastAccessed} is updated.
+ */
+export async function addOrUpdateRequestInDB(entry: RequestSchema): Promise<void> {
+    const db = await openDB();
+    const key = getKey(entry.domain, entry.mainDomain);
+
+    const transaction = db.transaction([STORE_ENTRIES], "readwrite");
+    const store = transaction.objectStore(STORE_ENTRIES);
+
+    const newEntry: RequestEntryInternal = {
+        ...entry,
+        key,
+        lastAccessed: now(),
+    };
+
+    store.put(newEntry);
+
+    const count = await getEntryCount(store);
+    if (count + 1 > MAX_ENTRIES) {
+        await evictLRU(store, EVICT_COUNT);
+    }
+
+    await transactionDone(transaction);
+}
+
+/**
+ * Finds a returns the first entry that matches the {@link domain}. Returns `null` if no such element
+ * was found.
+ *
+ * This function also updates the {@link RequestEntryInternal.lastAccessed} to the current timestamp,
+ * if an element was found.
+ */
+export async function findRequestInDB(domain: RequestSchema[typeof DOMAIN]): Promise<RequestSchema | null> {
+    const db = await openDB();
+    const transaction = db.transaction(STORE_ENTRIES, "readwrite");
+    const store = transaction.objectStore(STORE_ENTRIES);
+    const index = store.index(INDEX_DOMAIN);
+
+    // since we only need a single entry that matches the `domain` and a secondary index
+    // exists on the domain, it suffices to read from the cursor
+    const req = index.openCursor(IDBKeyRange.only(domain));
+    const entry = await new Promise<RequestEntryInternal | null>(
+        (resolve, reject) => {
+            req.onsuccess = () => {
+                const cursor = req.result;
+                if (!cursor) {
+                    resolve(null);
+                    return;
+                }
+                resolve(cursor.value as RequestEntryInternal);
+            };
+            req.onerror = () => reject(req.error);
+        }
+    );
+
+    // no entry was found that matched the requested `domain`, return null in this case
+    if (!entry) {
+        await transactionDone(transaction);
+        return null;
+    }
+
+    // update the timestamp, as this entry was requested
+    entry.lastAccessed = now();
+    store.put(entry);
+
+    await transactionDone(transaction);
+
+    return {
+        [DOMAIN]: entry.domain,
+        [MAIN_DOMAIN]: entry.mainDomain,
+        [SCION_ENABLED]: entry.scionEnabled,
+    };
+}
+
+/**
+ * Evicts all entries that are older than the timespan defined (in ms) by {@link MAX_TIME_ALIVE}.
+ *
+ * Note: This function already sets up the DB transaction, the caller therefore mustn't create one.
+ */
+export async function evictExpiredEntries() {
+    const db = await openDB();
+    const transaction = db.transaction([STORE_ENTRIES], "readwrite");
+    const store = transaction.objectStore(STORE_ENTRIES);
+
+    const index = store.index(INDEX_LAST_ACCESSED);
+    const cutoff = Date.now() - MAX_TIME_ALIVE;
+
+    // due to the index, it is sorted ascending by lastAccessed
+    const req = index.openCursor();
+
+    await new Promise<void>((resolve, reject) => {
+        req.onsuccess = () => {
+            const cursor = req.result as IDBCursorWithValue | null;
+            if (!cursor) {
+                resolve();
+                return;
+            }
+
+            const entry = cursor.value as RequestEntryInternal;
+
+            // since the index is sorted, we can stop early
+            if (entry.lastAccessed >= cutoff) {
+                resolve();
+                return;
+            }
+
+            store.delete(cursor.primaryKey);
+            cursor.continue();
+        };
+
+        req.onerror = () => reject(req.error);
+    });
+
+    await transactionDone(transaction);
+}
+
+/**
+ * Opens or returns the DB and ensures it is up-to-date.
+ */
+function openDB(): Promise<IDBDatabase> {
+    if (dbPromise) return dbPromise;
+
+    dbPromise = new Promise((resolve, reject) => {
+        const req = indexedDB.open(DB_NAME, DB_VERSION);
+
+        req.onupgradeneeded = () => {
+            const db = req.result;
+
+            const entryStore = db.createObjectStore(STORE_ENTRIES, {
+                keyPath: "key",
+            });
+
+            entryStore.createIndex(
+                INDEX_LAST_ACCESSED,
+                "lastAccessed",
+                {unique: false}
+            );
+
+            entryStore.createIndex(
+                INDEX_DOMAIN,
+                "domain",
+                {unique: false}
+            );
+        };
+
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+
+    return dbPromise;
+}
+
+/**
+ * Performs the eviction process of the '{@link count}' least recently used items in IDB.
+ *
+ * Note that this function neither handles opening nor closing of the transaction.
+ */
+async function evictLRU(store: IDBObjectStore, count: number): Promise<void> {
+    const index = store.index(INDEX_LAST_ACCESSED);
+
+    let removed = 0;
+    const req = index.openCursor(); // ascending TTL
+
+    await new Promise<void>((resolve, reject) => {
+        req.onsuccess = () => {
+            const cursor = req.result;
+            if (!cursor || removed >= count) {
+                resolve();
+                return;
+            }
+
+            store.delete(cursor.primaryKey);
+            removed++;
+            cursor.continue();
+        };
+        req.onerror = () => reject(req.error);
+    });
+}
+
+/**
+ * Returns the number of entries stored in the {@link store}.
+ *
+ * Note: This method of retrieving the total number of items might be slow for large stores. Alternatives
+ * such as keeping track of the number of items in a separate store could be considered if speed is crucial,
+ * though they introduce an additional point of failure - the reason why such an alternative was not implemented
+ * here.
+ */
+async function getEntryCount(store: IDBObjectStore): Promise<number> {
+    const request = store.count();
+    return await new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+/**
+ * Returns the key formed by the {@link domain} and {@link mainDomain}.
+ */
+function getKey(domain: string, mainDomain: string): string {
+    return `${domain}|${mainDomain}`;
+}
+
+/**
+ * Gets current timestamp.
+ */
+function now(): number {
+    return Date.now();
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+    return new Promise((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+        transaction.onabort = () => reject(transaction.error);
+    });
+}

--- a/chrome/shared/storage.ts
+++ b/chrome/shared/storage.ts
@@ -5,7 +5,6 @@ export const GLOBAL_STRICT_MODE = "globalStrictMode" as const;
 export const PER_SITE_STRICT_MODE = "perSiteStrictMode" as const;
 export const ISD_WHITELIST = "isd_whitelist" as const;
 export const ISD_ALL = "isd_all" as const;
-export const EXTENSION_RUNNING = "extension_running" as const;
 export const AUTO_PROXY_CONFIG = "auto-proxy-config" as const;
 export const PROXY_SCHEME = "proxyScheme" as const;
 export const PROXY_HOST = "proxyHost" as const;
@@ -25,9 +24,6 @@ export type SyncValueSchema = {
     // ISDs
     [ISD_WHITELIST]: string[];
     [ISD_ALL]: boolean;
-
-    // misc.
-    [EXTENSION_RUNNING]: boolean;
 };
 // ========================
 

--- a/chrome/shared/storage.ts
+++ b/chrome/shared/storage.ts
@@ -31,34 +31,10 @@ export type SyncValueSchema = {
 type SessionValueSchema = Record<string, boolean>;
 // ===========================
 
-// ===== LOCAL STORAGE =====
-const REQUESTS = "requests" as const;
-export const DOMAIN = "domain" as const;
-export const MAIN_DOMAIN = "mainDomain" as const;
-export const SCION_ENABLED = "scionEnabled" as const;
-
-export type RequestSchema = {
-    [DOMAIN]: string;
-    [MAIN_DOMAIN]: string;
-    [SCION_ENABLED]: boolean;
-};
-type RequestsSchema = {
-    [REQUESTS]: RequestSchema[];
-};
-/**
- * Note that the string corresponding to the `REQUESTS` key is a serialized representation of the `RequestsSchema` type.
- */
-type LocalValueSchema = {
-    [REQUESTS]: string;
-};
-// =========================
-
-// ===== LOCAL STORAGE TAB RESOURCES =====
+// ===== SESSION STORAGE TAB RESOURCES =====
 /*
-Instead of keeping a map in a single key in local storage as done with the requests, here
-each host for each tab is its own key to a boolean indicating whether the host is scion-capable.
-The reason not to use a map is the possibility of data races (see the requests' description below why
-this is not an issue there):
+Each host for each tab is its own key to a boolean indicating whether the host is scion-capable.
+The reason not to use a map is the possibility of data races:
 - When two requests to subresources are made asynchronously, both read the map, make their change
   and save it, thus one change gets overwritten. Such a history might be: rA, rB, wA, wB.
   Now this problem could be solved through a lock, as is done with the DNR rule IDs.
@@ -148,95 +124,6 @@ export async function addTabResource(tabId: number, resourceHostname: string, re
 
 // ====================================
 
-// ===== REQUESTS ENTRY =====
-// Data races are not a real concern for the requests table, as this is not something the user will see/notice.
-// Instead, if a race causes the result of one lookup to be lost, the extension will continue operating as normal
-// and will simply refetch that resource later on if it is requested again (since the entry does not exist, from
-// its perspective it considers this host to be unknown).
-
-const MAX_REQUEST_ENTRIES = 50; // keep list small (sync storage quota)
-
-async function loadRequests(): Promise<RequestSchema[]> {
-    const serializedRequests = await getLocalValue(REQUESTS);
-    if (serializedRequests && serializedRequests !== "") {
-        try {
-            const requestsObject = JSON.parse(serializedRequests) as RequestsSchema;
-            if (!requestsObject[REQUESTS]) return [];
-            return requestsObject[REQUESTS];
-        } catch {
-            return [];
-        }
-    }
-
-    return [];
-}
-
-/**
- * Returns a list of requests that match the condition provided in the `filter` or all requests
- * if `filter` is left `undefined`.
- *
- * Note that hostnames in request-entries are in punycode format.
- */
-export async function getRequests<K extends keyof RequestSchema>(filter: Partial<RequestSchema> | undefined = undefined): Promise<RequestSchema[]> {
-    let requests: RequestSchema[] = await loadRequests();
-    if (filter === undefined) return requests;
-
-    const keys = Object.keys(filter) as K[];
-    keys.forEach((key: K) => {
-        requests = requests.filter((requestEntry: RequestSchema) => requestEntry[key] === filter[key]);
-    })
-    return requests;
-}
-
-/**
- * Returns the first request that matches the condition provided in the `filter` or the overall
- * first request if `filter` is left `undefined`.
- *
- * Note that hostnames in request-entries are in punycode format.
- */
-export async function firstRequest(filter: Partial<RequestSchema> | undefined = undefined): Promise<RequestSchema | null> {
-    const filteredRequests: RequestSchema[] = await getRequests(filter);
-    if (!filteredRequests || filteredRequests.length === 0) return null;
-    return filteredRequests[0];
-}
-
-/**
- * Adds the provided `entry` to the list of requests or updates the first one request that matches
- * the `replaceFilter`.
- *
- * Note that the hostnames contained in `entry` must already be in punycode format (see {@link normalizedHostname}).
- */
-export async function addRequest<K extends keyof RequestSchema>(entry: RequestSchema, replaceFilter: Partial<RequestSchema> | undefined = undefined) {
-    const requests: RequestSchema[] = await loadRequests();
-    while (requests.length > MAX_REQUEST_ENTRIES) requests.shift();
-
-    if (replaceFilter === undefined) {
-        requests.push(entry);
-    } else {
-
-        const index: number = requests.findIndex((requestEntry: RequestSchema) => {
-            let match = true;
-            const keys = Object.keys(replaceFilter) as K[];
-            for (const key of keys) {
-                if (requestEntry[key] !== replaceFilter[key]) {
-                    match = false;
-                    break;
-                }
-            }
-            return match;
-        });
-
-        if (index < 0) requests.push(entry);
-        else {
-            requests[index] = {...requests[index], ...entry};
-        }
-    }
-
-    await saveLocalValue(REQUESTS, JSON.stringify({requests}));
-}
-
-// ==========================
-
 // ===== CHROME STORAGE WRAPPER FUNCTIONS =====
 export async function saveSyncValue<K extends keyof SyncValueSchema>(key: K, value: SyncValueSchema[K]) {
     await chrome.storage.sync.set({[key]: value});
@@ -279,15 +166,6 @@ export async function getSyncValues<K extends keyof SyncValueSchema>(keysWithFal
     const result = {} as Pick<SyncValueSchema, K>;
     for (const key of keys) result[key] = storage[key] ?? keysWithFallbacks[key];
     return result;
-}
-
-async function saveLocalValue<K extends keyof LocalValueSchema>(key: K, value: LocalValueSchema[K]) {
-    await chrome.storage.local.set({[key]: value});
-}
-
-async function getLocalValue<K extends keyof LocalValueSchema>(key: K): Promise<LocalValueSchema[K]> {
-    const result = await chrome.storage.local.get([key]);
-    return result[key] as LocalValueSchema[K];
 }
 
 async function saveSessionValue(key: keyof SessionValueSchema, value: SessionValueSchema[string]) {

--- a/chrome/shared/utilities.ts
+++ b/chrome/shared/utilities.ts
@@ -1,3 +1,5 @@
+import {getSyncValue, GLOBAL_STRICT_MODE, PER_SITE_STRICT_MODE, saveSyncValue, type SyncValueSchema} from "./storage.js";
+
 /**
  * Normalizes the `hostname` to be in punycode format.
  * @param hostname the `hostname` to be converted.
@@ -17,4 +19,27 @@ export function safeHostname(url: string | URL): string | null {
     } catch {
         return null;
     }
+}
+
+export let GlobalStrictMode: SyncValueSchema[typeof GLOBAL_STRICT_MODE] = false;
+export let PerSiteStrictMode: SyncValueSchema[typeof PER_SITE_STRICT_MODE] = {};
+
+export async function initializeStrictModes() {
+    const storageGlobalStrictMode = await getSyncValue(GLOBAL_STRICT_MODE);
+    GlobalStrictMode = storageGlobalStrictMode ?? false;
+    if (storageGlobalStrictMode === undefined) await saveSyncValue(GLOBAL_STRICT_MODE, GlobalStrictMode);
+    console.log("[initializeStrictModes]: GlobalStrictMode:", GlobalStrictMode);
+
+    const storagePerSiteStrictMode = await getSyncValue(PER_SITE_STRICT_MODE);
+    PerSiteStrictMode = storagePerSiteStrictMode ?? {};
+    if (storagePerSiteStrictMode === undefined) await saveSyncValue(PER_SITE_STRICT_MODE, PerSiteStrictMode);
+    console.log("[initializeStrictModes]: PerSiteStrictMode:", PerSiteStrictMode);
+}
+
+export function setGlobalStrictMode(globalStrictMode: SyncValueSchema[typeof GLOBAL_STRICT_MODE]) {
+    GlobalStrictMode = globalStrictMode;
+}
+
+export function setPerSiteStrictMode(perSiteStrictMode: SyncValueSchema[typeof PER_SITE_STRICT_MODE]) {
+    PerSiteStrictMode = perSiteStrictMode;
 }

--- a/chrome/testing.md
+++ b/chrome/testing.md
@@ -1,0 +1,60 @@
+# Testing the Extension
+
+Several aspects and behaviour need to be tested to ensure proper functionality of the extension.
+Testing is currently only done manually, but automation of this process is to be considered in the future.
+
+Any examples that are listed below reflect their SCION-capability at the time of writing (10.2.26).
+
+## Tests to conduct
+- Browsing without any strict modes enabled
+    - All websites should be accessible
+    - The popup should reflect the resources loaded by that website
+- Browsing with global strict mode enabled
+    - All websites that are SCION-capable (e.g. `ethz.ch`, `ovgu.de`) should be accessible
+        - The popup should display the resources that were allowed (whose hosts are SCION-capable) and
+          the resources that were blocked (whose hosts are not SCION-capable)
+        - Any sub-resources whose hosts are not SCION-capable of such websites (e.g. `www.googletagmanager.com`)
+          should be blocked (in case of `ethz.ch`, this results in the Cookie-banner not being loaded)
+    - All websites that are not SCION-capable (e.g. `example.com`, `www.google.com`) should be blocked
+        - The checking-page should indicate that the page was blocked
+        - The popup should also indicate, that the host of the website was blocked
+- Browsing with per-site strict mode set for some page(s) with global strict mode enabled
+    - Should result in the same behaviour as if no per-site strict mode was enabled
+- Browsing with per-site strict mode set for some page(s) with global strict mode disabled
+    - All websites (except the ones set to strict) should be accessible
+    - Those set to strict should behave the same way, as if global strict mode was set
+- Verify that the connection is performed via SCION by checking if `http://gazelle.scionapps.com`
+  shows a dancing gazelle
+
+### Example Testing-workflow
+Important to note again, that these examples are based on the SCION-capability of those hosts at the
+time of writing.
+
+Additionally, for each of the following pages that are accessed, the popup should also be verified to
+show the resources that were loaded/blocked. Note that this list may differ from the list observed
+when no strict mode is enabled, since without strict mode, a resource that would otherwise be blocked
+may request further resources (e.g. browsing `ethz.ch` without strict mode will not only show `ethz.ch` and
+`www.googletagmanager.com`, but also `geolocation.onetrust.com` and `cdn.cookielaw.org` - both of which are
+requested by `www.googletagmanager.com` and therefore do not show up in strict mode at all).
+
+- No strict modes enabled
+    - Verify accessibility of:
+        - `example.com`
+        - `ethz.ch`
+        - `ovgu.de`
+- Global strict mode enabled (without any per-site strict mode)
+    - Verify blocking of:
+        - `example.com`
+    - Verify accessibility of:
+        - `ethz.ch` (ensure the Cookie-banner is blocked)
+        - `ovgu.de`
+- Per-site strict mode enabled for `ethz.ch` and `www.google.com` (with global strict mode enabled)
+    - Verify same behaviour as if exclusively global strict mode was enabled
+- Per-site strict mode enabled for `ethz.ch` and `www.google.com` (with global strict mode disabled)
+    - Verify blocking of:
+        - `www.google.com`
+    - Verify accessibility of:
+        - `example.com`
+        - `ovgu.de`
+        - `ethz.ch` (but ensure the Cookie-banner is blocked)
+- Verify SCION-usage by checking if `http://gazelle.scionapps.com` shows a dancing gazelle

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,13 +6,6 @@ You can find the source code on https://github.com/scionproto-contrib/browser-ex
 
 The SCION browser extension is part of a broader group of `SCION Applications <https://docs.scion.org/projects/scion-applications/en/latest>`_ .
 
-.. note::
-    The `latest version <https://github.com/scionproto-contrib/browser-extension/releases/tag/v0.3.0-beta>`_ of the extension  
-    contains a known limitation of 30000 DNR rules (equivalent of resolved hostnames under ``strict-mode``). 
-    Therefore, in case that limit is exceeded, ``strict-mode`` may no longer behave as intended. 
-    In this case, it is advised to reinstall the extension.
-    A future release will address this issue.
-
 
 Requirements
 ------------


### PR DESCRIPTION
migrated storage location of DNR-rule-information from local storage to IndexedDB to more efficiently support LRU-based DNR rule eviction (including evicting items whose timestamp is longer than a predefined (currently hardcoded to 1 week) threshold)

Closes #17 

for future reference, a basic benchmark-file for `database.ts` can seen here: https://gist.github.com/Tekbuildz/9f499321cc8956a9909d03a19185cb32